### PR TITLE
Response is named h-captcha-response in form, not h-recaptcha-response

### DIFF
--- a/flask_hcaptcha.py
+++ b/flask_hcaptcha.py
@@ -61,7 +61,7 @@ class hCaptcha(object):
         if self.is_enabled:
             data = {
                 "secret": BlueprintCompatibility.secret_key,
-                "response": response or request.form.get('h-recaptcha-response'),
+                "response": response or request.form.get('h-captcha-response'),
                 "remoteip": remote_ip or request.environ.get('REMOTE_ADDR')
             }
 


### PR DESCRIPTION
Hi, the verification wasn't working, it seems the property you are looking for is (now?) called h-captcha-response instead of h-recaptcha-response. With this little change, things started working again (for me at least).