### PR TITLE
Add support for Jinja 3.1.x

### DIFF
--- a/flask_hcaptcha.py
+++ b/flask_hcaptcha.py
@@ -10,7 +10,10 @@ __copyright__ = "(c) 2020 Knugi (originally ReCaptcha by Mardix 2015)"
 
 try:
     from flask import request
-    from jinja2 import Markup
+    try:
+        from jinja2 import Markup
+    except ImportError:
+        from markupsafe import Markup
     import requests
 except ImportError as ex:
     print("Missing dependencies")


### PR DESCRIPTION
Jinja 3.1.0 removes jinja2.Markup, which has been deprecated since version 2.5.1 (https://jinja.palletsprojects.com/en/3.1.x/changes/#version-2-5-1). 
The suggested replacement is markupsafe.Markup (https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0)
This PR patches this by first attempting to import jinja2.Markup, and then falling back to markupsafe.Markup.